### PR TITLE
Fix the validation for finished filter in reports

### DIFF
--- a/app/Http/Requests/ReportRequest.php
+++ b/app/Http/Requests/ReportRequest.php
@@ -46,7 +46,7 @@ class ReportRequest extends FormRequest
                 'string',
                 'date_format:Y-m-d',
             ],
-            'filter.end' => [
+            'filter.finished' => [
                 'nullable',
                 'string',
                 'date_format:Y-m-d',


### PR DESCRIPTION
This PR fixes a bug that was not reported: the validation for `finished` filter in reports was not working properly. This was happening because the field name was not right -- probably due to a typo or an old name.