### PR TITLE
Decimal time

### DIFF
--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -47,9 +47,9 @@ class ReportsController extends Controller
         $grandTotal = 0;
         $totals = (clone $query)->selectActivityTotals()->pluck('total', 'name')->map(function ($total) use (&$grandTotal) {
             $grandTotal += $total;
-            return config('settings.time_decimal', false) ? Formatter::decimalIntervalFromSeconds($total) : Formatter::intervalFromSeconds($total);
+            return config('tracker.time_decimal', false) ? Formatter::decimalIntervalFromSeconds($total) : Formatter::intervalFromSeconds($total);
         });
-        $grandTotal = config('settings.time_decimal', false) ? Formatter::decimalIntervalFromSeconds($grandTotal) : Formatter::intervalFromSeconds($grandTotal);
+        $grandTotal = config('tracker.time_decimal', false) ? Formatter::decimalIntervalFromSeconds($grandTotal) : Formatter::intervalFromSeconds($grandTotal);
 
         $data = [
             'reports' => $reports,

--- a/app/Http/Controllers/ReportsController.php
+++ b/app/Http/Controllers/ReportsController.php
@@ -47,9 +47,9 @@ class ReportsController extends Controller
         $grandTotal = 0;
         $totals = (clone $query)->selectActivityTotals()->pluck('total', 'name')->map(function ($total) use (&$grandTotal) {
             $grandTotal += $total;
-            return Formatter::intervalFromSeconds($total);
+            return config('settings.time_decimal', false) ? Formatter::decimalIntervalFromSeconds($total) : Formatter::intervalFromSeconds($total);
         });
-        $grandTotal = Formatter::intervalFromSeconds($grandTotal);
+        $grandTotal = config('settings.time_decimal', false) ? Formatter::decimalIntervalFromSeconds($grandTotal) : Formatter::intervalFromSeconds($grandTotal);
 
         $data = [
             'reports' => $reports,

--- a/app/Http/Controllers/SharedReportsController.php
+++ b/app/Http/Controllers/SharedReportsController.php
@@ -53,7 +53,7 @@ class SharedReportsController extends Controller
         foreach ($times as $time) {
             $ellapsed = null;
             if ($time->finished) {
-                $ellapsed = Formatter::intervalFromDates($time->started, $time->finished, true);
+                $ellapsed = config('settings.time_decimal', false) ? Formatter::decimalIntervalFromDates($time->started, $time->finished): Formatter::decimalIntervalFromDates($time->started, $time->finished, true);
             }
             $rows[] = [
                 $time->project->name,

--- a/app/Http/Controllers/SharedReportsController.php
+++ b/app/Http/Controllers/SharedReportsController.php
@@ -53,7 +53,7 @@ class SharedReportsController extends Controller
         foreach ($times as $time) {
             $ellapsed = null;
             if ($time->finished) {
-                $ellapsed = config('settings.time_decimal', false) ? Formatter::decimalIntervalFromDates($time->started, $time->finished): Formatter::decimalIntervalFromDates($time->started, $time->finished, true);
+                $ellapsed = config('tracker.time_decimal', false) ? Formatter::decimalIntervalFromDates($time->started, $time->finished): Formatter::decimalIntervalFromDates($time->started, $time->finished, true);
             }
             $rows[] = [
                 $time->project->name,

--- a/app/Models/Time.php
+++ b/app/Models/Time.php
@@ -61,7 +61,7 @@ class Time extends Model
             return null;
         }
 
-        return Formatter::intervalFromDates($this->started, $this->finished);
+        return config('settings.time_decimal', false) ? Formatter::decimalIntervalFromDates($this->started, $this->finished) : Formatter::intervalFromDates($this->started, $this->finished);
     }
 
     /**

--- a/app/Models/Time.php
+++ b/app/Models/Time.php
@@ -61,7 +61,7 @@ class Time extends Model
             return null;
         }
 
-        return config('settings.time_decimal', false) ? Formatter::decimalIntervalFromDates($this->started, $this->finished) : Formatter::intervalFromDates($this->started, $this->finished);
+        return config('tracker.time_decimal', false) ? Formatter::decimalIntervalFromDates($this->started, $this->finished) : Formatter::intervalFromDates($this->started, $this->finished);
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -23,6 +24,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Config::set('settings.time_decimal', true);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace App\Providers;
 
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -24,6 +23,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        Config::set('settings.time_decimal', true);
+        //
     }
 }

--- a/app/Support/Formatter.php
+++ b/app/Support/Formatter.php
@@ -36,4 +36,17 @@ class Formatter
     {
         return self::interval(CarbonInterval::seconds($interval)->cascade(), $seconds);
     }
+
+    public static function decimalIntervalFromDates(Carbon $from, Carbon $to = null)
+    {
+        if ($to === null) {
+            $to = Carbon::now();
+        }
+        return $to->diffAsCarbonInterval($from)->totalHours;
+    }
+
+    public static function decimalIntervalFromSeconds(int $interval)
+    {
+        return CarbonInterval::seconds($interval)->cascade()->totalHours;
+    }
 }

--- a/app/Support/Formatter.php
+++ b/app/Support/Formatter.php
@@ -37,16 +37,16 @@ class Formatter
         return self::interval(CarbonInterval::seconds($interval)->cascade(), $seconds);
     }
 
-    public static function decimalIntervalFromDates(Carbon $from, Carbon $to = null)
+    public static function decimalIntervalFromDates(Carbon $from, Carbon $to = null, int $precision = 2)
     {
         if ($to === null) {
             $to = Carbon::now();
         }
-        return $to->diffAsCarbonInterval($from)->totalHours;
+        return round($to->diffAsCarbonInterval($from)->totalHours, $precision);
     }
 
-    public static function decimalIntervalFromSeconds(int $interval)
+    public static function decimalIntervalFromSeconds(int $interval, int $precision = 2)
     {
-        return CarbonInterval::seconds($interval)->cascade()->totalHours;
+        return round(CarbonInterval::seconds($interval)->cascade()->totalHours, $precision);
     }
 }

--- a/config/tracker.php
+++ b/config/tracker.php
@@ -1,0 +1,20 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Time Decimal
+    |--------------------------------------------------------------------------
+    |
+    | This option controls how time should be rendered in the app and reports 
+    | as decimal of hours, instead of hours and minutes. If it is set to 
+    | "true", 1 hour and 14 minutes will be rendered as 1.23 instead of 1:14.
+    |
+    | Changing this option value only affects rendering and not how values are  
+    | stored in the database.
+    */
+
+    'time_decimal' => false,
+
+];


### PR DESCRIPTION
Added an option to enable time rendering as a decimal of hour instead of `hh:mm` (hour and minute) format.

The option value can be changed on `config/tracker.php` file.